### PR TITLE
bugfix 0.4.1

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -1,7 +1,7 @@
 import torch
 
 from imageio import imread, imsave
-from scipy import imresize
+from scipy.misc import imresize
 import numpy as np
 from path import Path
 import argparse
@@ -65,7 +65,7 @@ def main():
         tensor_img = torch.from_numpy(img).unsqueeze(0)
         tensor_img = ((tensor_img/255 - 0.5)/0.2).to(device)
 
-        output = disp_net(img)[0]
+        output = disp_net(tensor_img)[0]
 
         if args.output_disp:
             disp = (255*tensor2array(output, max_value=None, colormap='bone')).astype(np.uint8)

--- a/train.py
+++ b/train.py
@@ -309,8 +309,8 @@ def train(args, train_loader, disp_net, pose_exp_net, optimizer, epoch_size, log
                 b, _, h, w = scaled_depth.size()
                 downscale = tgt_img.size(2)/h
 
-                tgt_img_scaled = F.interpolate(tgt_img, (h, w), method='area', align_corners=False)
-                ref_imgs_scaled = [nn.functional.adaptive_avg_pool2d(ref_img, (h, w)) for ref_img in ref_imgs]
+                tgt_img_scaled = F.interpolate(tgt_img, (h, w), method='area')
+                ref_imgs_scaled = [F.interpolate(ref_img, (h, w), methode='area') for ref_img in ref_imgs]
 
                 intrinsics_scaled = torch.cat((intrinsics[:, 0:2]/downscale, intrinsics[:, 2:]), dim=1)
                 intrinsics_scaled_inv = torch.cat((intrinsics_inv[:, :, 0:2]*downscale, intrinsics_inv[:, :, 2:]), dim=2)

--- a/utils.py
+++ b/utils.py
@@ -42,7 +42,7 @@ def tensor2array(tensor, max_value=255, colormap='rainbow'):
     if tensor.ndimension() == 2 or tensor.size(0) == 1:
         try:
             import cv2
-            if cv2.__version__.startswith('3'):
+            if int(cv2.__version__[0]) >= 3:
                 color_cvt = cv2.COLOR_BGR2RGB
             else:  # 2.4
                 color_cvt = cv2.cv.CV_BGR2RGB
@@ -57,7 +57,6 @@ def tensor2array(tensor, max_value=255, colormap='rainbow'):
             if tensor.ndimension() == 2:
                 tensor.unsqueeze_(2)
             array = (tensor.expand(tensor.size(0), tensor.size(1), 3).numpy()/max_value).clip(0,1)
-        array = array.transpose(2, 0, 1)
 
     elif tensor.ndimension() == 3:
         assert(tensor.size(0) == 3)


### PR DESCRIPTION
- solved #6, wrong kwarg for interpolate
- solved bad img_tensor call for run_inference
- aligned with last version of tensorboard where arrays are expected to be of form CHW and not HWC